### PR TITLE
S0008 - add cached page with SSG

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,7 +3,7 @@ import { useKeenSlider } from 'keen-slider/react'
 import { HomeContainer, Product } from "../styles/pages/home";
 
 import 'keen-slider/keen-slider.min.css'
-import { GetServerSideProps } from "next";
+import { GetStaticProps } from "next";
 import { stripe } from "../lib/stripe";
 import Stripe from "stripe";
 
@@ -41,7 +41,7 @@ export default function Home({ products }: IHomeProps) {
 }
 
 
-export const getServerSideProps: GetServerSideProps = async () => {
+export const getStaticProps: GetStaticProps = async () => {
   const response = await stripe.products.list({
     expand: ['data.default_price']
   })
@@ -58,6 +58,7 @@ export const getServerSideProps: GetServerSideProps = async () => {
   return {
     props: {
       products,
-    }
+    },
+    revalidate: 60 * 60 / 2 // revalidar cache da página cada 2h
   }
 }


### PR DESCRIPTION
Em ambiente dev o getStaticProps é tratado igual ao getServerSideProps; 

Em ambiente prod/build o getStaticProps faz com que a página seja cacheada. 
O seu cache é revalidado de acordo com o tempo configurando no revalidate, 
ou seja, se houver um revalidate de 10min, significa que a cada 10min que um 
usuário acessar a página, o next irá gerar uma nova página e cachea-lá. 
Assim, todos os outros usuário que acessar a página, irão ver a mesma página cacheada;

No getServerSideProps, conseguimos ter acesso ao contexto da requisição via props.
Porém no getStaticProps não é possível, pois o mesmo executa somente no momento que o next estiver criando
uma versão estática, (build) ou revalidado o cache;
No momento do build da aplicação, todas as páginas com getStaticProps é gerada como estática;
Importante: Caso uma requisição dentro do getStaticProps precisar de algumas informação do usuário,
isso nao será possível, pois o getStaticProps não tem acesso ao contexto da requisição.
