### PR TITLE
S0012 - add getStaticPaths for dynamic ssg and fallback

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,7 +15,7 @@ interface IHomeProps {
     id: string;
     name: string;
     imageUrl: string;
-    price: number;
+    price: string;
   }[]
 }
 

--- a/src/pages/product/[productId].tsx
+++ b/src/pages/product/[productId].tsx
@@ -1,28 +1,75 @@
-import { useRouter } from 'next/router'
+import { GetStaticPaths, GetStaticProps } from 'next'
+import Image from 'next/image'
+import Stripe from 'stripe'
+import { stripe } from '../../lib/stripe'
 import { ImageContainer, ProductContainer, ProductDetails } from '../../styles/pages/product'
+import { useRouter } from 'next/router'
 
-export default function Product() {
+interface IProductProps {
+  product: {
+    id: string;
+    name: string;
+    imageUrl: string;
+    price: string;
+    description: string;
+  }
+}
+export default function Product({ product }: IProductProps) {
 
-  const { query } = useRouter()
+  const { isFallback } = useRouter()
+
+  if (isFallback) {
+    return <p>Carregando...</p>
+  }
 
   return (
     <ProductContainer>
       <ImageContainer>
-        <img src="" alt="xpto" />
+        <Image src={product.imageUrl} width={520} height={480} alt="" />
       </ImageContainer>
       <ProductDetails>
-        <h1>Camiseta X</h1>
-        <span>R$ 79,90</span>
-        <p>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit.
-          Recusandae, debitis doloribus assumenda fugit magnam,
-          alias deserunt dolor ad nemo fugiat illo a error velit.
-          Quos animi deserunt voluptate quasi ratione!
-        </p>
+        <h1>{product.name}</h1>
+        <span>{product.price}</span>
+        <p>{product.description}</p>
         <button>
           Comprar agora
         </button>
       </ProductDetails>
     </ProductContainer>
   )
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [
+      {
+        params: { productId: 'prod_O3HM6OZmvd9Qv8' }
+      }
+    ],
+    fallback: true,
+  }
+}
+
+export const getStaticProps: GetStaticProps<any, { productId: string }> = async ({ params }) => {
+  const productId = params.productId
+  const product = await stripe.products.retrieve(productId, {
+    expand: ['default_price'],
+  })
+
+  const price = (product.default_price as Stripe.Price).unit_amount / 100
+  return {
+    props: {
+      product: {
+        id: product.id,
+        name: product.name,
+        imageUrl: product.images[0],
+        price: new Intl.NumberFormat('pt-br', {
+          style: 'currency',
+          currency: 'BRL'
+        }).format(price),
+        description: product.description,
+      }
+    },
+    revalidate: 60 * 60 / 2 // revalidar cache da página cada 2h
+  }
 }


### PR DESCRIPTION
O que aprendi utilizando o getStaticProps?

O getStaticProps é uma funcionalidade do Next para gerar páginas estáticas no servidor e devolver pro client a página montada e cacheada.

Devemos analisar algumas questões antes de utilizar o getStaticProps.

  - A página precisa de SEO e indexação?
  - A página não precisa de acesso a token do usuário, cookies e etc?
  - As informações da página muda com pouca frequência?

Se as respostas forem SIM, ok, é uma boa utilizar o getStaticProps, assim temos uma versão estática da página e cacheada, evitando requests desnecessários pro servidor sempre que o usuário acessa-la.

Utilizando getStaticProps, podemos configurar um tempo de `revalidate` para que a página seja novamente gerada e cacheada.

Quando se trata de uma página que recebe um parâmetro de rota e queremos utlizar o `getStaticProps`, obrigatoriamente precisamos utilizar o `getStaticPaths`, no qual fica a definição dos parâmetros que `getStaticProps` irá utilizar para gerar as páginas. Isso é necessário, pois o `getStaticProps` é executado em duas situações, no momento do `revalidate` em runtime e no momento do `build`. Quando se trata do momento do build, o `getStaticProps` não tem conhecimento de quais parâmetros será utlizado, por isso se faz necessário defini-los em `getStaticPaths`.

Ok, mas e se tivermos 20 mil parâmetros, devemos definir todos eles no `getStaticPaths`?

Não, pois além de ser inviável e nao escalável, o `build` iria levar bastante tempo pra gerar todas essas páginas.
O recomendado é definir os parâmetros que fazem sentido pro momento do `build` e configurar um `fallback` para `true`, ou seja, com um `fallback` o Next JS irá no momento que a página for acessada, gerar o HTML da mesma e de forma assíncrona, executar o `getStaticProps` com o parâmetro que está sendo passado no momento do acesso a página e após finalizar a execução, irá devolver o `JSON` e gerar uma versão estática e cacheada da página.
Um detalhe importante, é que se o `fallback` estiver configurado para `false`, as páginas que não tiverem seus parâmetros definidos no `getStaticPaths`, irá retornar `404` pro usuário.