### PR TITLE
S0013 - disable prefetch link

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -31,7 +31,7 @@ export default function Home({ products }: IHomeProps) {
   return (
     <HomeContainer ref={sliderRef} className="keen-slider">
       {products.map(product => (
-        <Link key={product.id} href={`/product/${product.id}`}>
+        <Link key={product.id} href={`/product/${product.id}`} prefetch={false}>
           <Product className="keen-slider__slide">
             <Image src={product.imageUrl} width={520} height={480} alt="" />
             <footer>


### PR DESCRIPTION
O que aprendi nessa aula e estou documentando nessa MR?

Por padrão o Next faz prefetch de páginas, sempre que um componente `<Link />` está em tela.
O Next utiliza da api da web `Intersection Observer` para observar um Link em tela e deixar a página já carregada para quando o usuário acessa-la, o carregamento ser imediato.

Porém em uma tela que existe centenas de Links esse pretch pode ficar custoso e deve ser utilizado com cautela.
Uma maneira de desabilitar é através da prop `prefetch={false}`